### PR TITLE
[EOS-10241] Avoid namespace-tenant auto-assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## 0.1.1-0.3.0 (2022-07-27)
 
-
+* [EOS-10241] Avoid namespace-tenant auto-assignment
 * [EOS-6302] Bump Capsule upstream version to v0.1.1
-
 
 ## Previous development
 

--- a/pkg/webhook/ownerreference/patching.go
+++ b/pkg/webhook/ownerreference/patching.go
@@ -145,12 +145,6 @@ func (h *handler) setOwnerRef(ctx context.Context, req admission.Request, client
 		return &response
 	}
 
-	if len(tenants) == 1 {
-		response := h.patchResponseForOwnerRef(&tenants[0], ns, recorder)
-
-		return &response
-	}
-
 	if h.cfg.ForceTenantPrefix() {
 		for _, tnt := range tenants {
 			if strings.HasPrefix(ns.GetName(), fmt.Sprintf("%s-", tnt.GetName())) {
@@ -160,6 +154,12 @@ func (h *handler) setOwnerRef(ctx context.Context, req admission.Request, client
 			}
 		}
 		response := admission.Denied("The Namespace prefix used doesn't match any available Tenant")
+
+		return &response
+	}
+
+	if len(tenants) == 1 {
+		response := h.patchResponseForOwnerRef(&tenants[0], ns, recorder)
 
 		return &response
 	}


### PR DESCRIPTION
<!--
# General contribution criteria

Thanks for spending some time for improving and fixing Capsule!

We're still working on the outline of the contribution guidelines but we're
following ourselves these points:

- reference a previously opened issue: https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests 
- including a sentence or two in the commit description for the
  changelog/release notes
- splitting changes into several and documented small commits
- limit the git subject to 50 characters and write as the continuation of the
  sentence "If applied, this commit will ..."
- explain what and why in the body, if more than a trivial change, wrapping at
  72 characters

If you have any issue or question, reach out us!
https://clastix.slack.com >>> #capsule channel 
-->
