### PR TITLE
[PLT] Fix tenant mutating webhook: aceptar solicitudes v1beta1 via conversion

### DIFF
--- a/charts/capsule/templates/configuration.yaml
+++ b/charts/capsule/templates/configuration.yaml
@@ -1309,7 +1309,7 @@ spec:
           - apiGroups:
               - capsule.clastix.io
             apiVersions:
-              - "*"
+              - v1beta2
             operations:
               - CREATE
               - UPDATE

--- a/charts/capsule/values.yaml
+++ b/charts/capsule/values.yaml
@@ -905,7 +905,7 @@ webhooks:
       # -- [FailurePolicy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy)
       failurePolicy: Fail
       # -- [MatchPolicy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy)
-      matchPolicy: Exact
+      matchPolicy: Equivalent
       # -- [ObjectSelector](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-objectselector)
       objectSelector: {}
       # -- [NamespaceSelector](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector)


### PR DESCRIPTION
## Resumen

Este PR corrige un error en la configuracion del webhook mutante de Tenants que provoca que los clientes que envian solicitudes usando la API `v1beta1` (como CCT Orchestrator) reciban el siguiente error:

```
admission webhook "tenants.mutating.projectcapsule.dev" denied the request:
unable to decode capsule.clastix.io/v1beta1, Kind=Tenant into *v1beta2.Tenant
```

## Causa raiz

El webhook mutante de Tenants tenia configuradas dos opciones incorrectas en la `CapsuleConfiguration`:

1. **`apiVersions: "*"`** - El caracter `*` hace que la regla del webhook coincida con cualquier version directamente. Cuando un cliente envia una solicitud `v1beta1`, el API server la reenvía al webhook sin conversion, porque el `*` ya coincide exactamente.

2. **`matchPolicy: Exact`** - Con esta politica, el API server solo llama al webhook cuando la solicitud coincide exactamente con la regla. Al combinarlo con `apiVersions: "*"`, el objeto llega al webhook en la version original del cliente (`v1beta1`).

El handler del webhook intenta deserializar el objeto entrante directamente como `*v1beta2.Tenant` (ver `internal/webhook/tenant/validation/handler.go`). Cuando el objeto tiene `apiVersion: capsule.clastix.io/v1beta1`, la deserializacion falla porque el esquema del runtime no tiene registrada una funcion de conversion para el contexto de admission.

Esto contrasta con el **webhook validante** de Tenants, que ya usaba correctamente `apiVersions: v1beta2`.

## Cambios

| Fichero | Campo | Antes | Despues |
|---|---|---|---|
| `charts/capsule/templates/configuration.yaml` | `apiVersions` (webhook mutante de tenants) | `"*"` | `v1beta2` |
| `charts/capsule/values.yaml` | `webhooks.hooks.tenants.matchPolicy` | `Exact` | `Equivalent` |

## Como funciona el fix

Con `apiVersions: v1beta2` y `matchPolicy: Equivalent`:

- El API server recibe una solicitud `v1beta1` de un cliente.
- La regla del webhook no coincide directamente (la version es `v1beta1`, no `v1beta2`).
- Con `Equivalent`, el API server detecta que `v1beta1` y `v1beta2` son el mismo recurso subyacente.
- El API server convierte el objeto de `v1beta1` a `v1beta2` usando el **CRD conversion webhook** antes de enviarlo al admission webhook.
- El handler recibe un objeto `v1beta2` y lo deserializa correctamente.

Este comportamiento ya era el correcto para el webhook validante (que usaba `v1beta2` + `Equivalent`). Este PR alinea el webhook mutante con el mismo patron.

## Plan de pruebas

- [ ] Desplegar Capsule 1.0.x con este cambio.
- [ ] Crear un Tenant usando la API `v1beta1` (ej. desde CCT Orchestrator).
- [ ] Verificar que la creacion del Tenant no genera el error `unable to decode v1beta1 into *v1beta2.Tenant`.
- [ ] Verificar que el webhook mutante aplica correctamente las mutaciones al Tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)